### PR TITLE
Add site-wide announcement bar for experimental site disclosure

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,6 +83,14 @@ const config = {
           },
         ],
       },
+      announcementBar: {
+        id: 'experimental_site',
+        content:
+          '🧪 This is an experimental site exploring platform engineering, observability, and site reliability. We\'re testing new features like agentic AI here!',
+        backgroundColor: '#20232a',
+        textColor: '#fff',
+        isCloseable: true,
+      },
       footer: {
         logo: {
           alt: 'amiable.dev logo',


### PR DESCRIPTION
This PR adds a site-wide announcement bar to inform visitors about the experimental nature of the blog. 

Changes made:
- Added announcement bar configuration to `docusaurus.config.js`
- Set up dismissible announcement with dark theme styling
- Added emoji for better visibility
- Included mention of platform engineering, observability, and agentic AI testing

The announcement bar will appear at the top of every page with the following message:
```
🧪 This is an experimental site exploring platform engineering, observability, and site reliability. We're testing new features like agentic AI here!
```

Testing Notes:
- Announcement should be visible on all pages
- Text should be readable against the dark background
- Dismiss button should work and persist across sessions
- Message should be clear and concise

Closes #18